### PR TITLE
[FEAT] 川柳ランキング一覧でタグごとに適切なデモデータ(ハリボテ)を表示するように改修

### DIFF
--- a/app/src/main/java/jp/chocofac/charlie/MainActivity.kt
+++ b/app/src/main/java/jp/chocofac/charlie/MainActivity.kt
@@ -30,14 +30,12 @@ import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navArgument
 import dagger.hilt.android.AndroidEntryPoint
-import jp.chocofac.charlie.data.service.senryu.Senryu
 import jp.chocofac.charlie.ui.page.CreateSenryuScreen
 import jp.chocofac.charlie.ui.page.HomeScreen
 import jp.chocofac.charlie.ui.page.LoginScreen
 import jp.chocofac.charlie.ui.page.PostedSenryuScreen
-import jp.chocofac.charlie.ui.page.RankingScreen
+import jp.chocofac.charlie.ui.page.ranking.RankingScreen
 import jp.chocofac.charlie.ui.theme.CharlieTheme
-import timber.log.Timber
 
 val LocalNavController = staticCompositionLocalOf<NavHostController> {
     error("No Current NavController")

--- a/app/src/main/java/jp/chocofac/charlie/ui/page/ranking/FunRankingScreen.kt
+++ b/app/src/main/java/jp/chocofac/charlie/ui/page/ranking/FunRankingScreen.kt
@@ -1,0 +1,27 @@
+package jp.chocofac.charlie.ui.page.ranking
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+
+@Composable
+fun FunRankingScreen() {
+    FunRankingContent()
+}
+
+@Composable
+fun FunRankingContent() {
+    val mockSenryu1 = Senryu("未来の夢", "広がる世界を", "手に取りたい")
+    val mockSenryu2 = Senryu("未来を見る", "ガラス張りの恐怖", "胸がざわめく")
+    val mockSenryu3 = Senryu("未来の夜", "美しく輝く", "感動の景色")
+    val names = listOf(
+        Senryu(mockSenryu1.firstLine, mockSenryu1.secondLine, mockSenryu1.thirdLine),
+        Senryu(mockSenryu2.firstLine, mockSenryu2.secondLine, mockSenryu2.thirdLine),
+        Senryu(mockSenryu3.firstLine, mockSenryu3.secondLine, mockSenryu3.thirdLine),
+        // 投稿数かさ増 2set分繰り返し
+        Senryu(mockSenryu1.firstLine, mockSenryu1.secondLine, mockSenryu1.thirdLine),
+        Senryu(mockSenryu2.firstLine, mockSenryu2.secondLine, mockSenryu2.thirdLine),
+        Senryu(mockSenryu3.firstLine, mockSenryu3.secondLine, mockSenryu3.thirdLine),
+    )
+    SenryuCardList(names = names)
+}

--- a/app/src/main/java/jp/chocofac/charlie/ui/page/ranking/GourmetRankingScreen.kt
+++ b/app/src/main/java/jp/chocofac/charlie/ui/page/ranking/GourmetRankingScreen.kt
@@ -3,15 +3,15 @@ package jp.chocofac.charlie.ui.page.ranking
 import androidx.compose.runtime.Composable
 
 @Composable
-fun FunRankingScreen() {
-    FunRankingContent()
+fun GourmetRankingScreen() {
+    GourmetRankingContent()
 }
 
 @Composable
-fun FunRankingContent() {
-    val mockSenryu1 = Senryu("未来の夢", "広がる世界を", "手に取りたい")
-    val mockSenryu2 = Senryu("未来を見る", "ガラス張りの恐怖", "胸がざわめく")
-    val mockSenryu3 = Senryu("未来の夜", "美しく輝く", "感動の景色")
+fun GourmetRankingContent() {
+    val mockSenryu1 = Senryu("イカ丼", "まじうまかった", "幸せ満開")
+    val mockSenryu2 = Senryu("海より濃い", "醤油や味噌じゃ", "なく塩ラーメン")
+    val mockSenryu3 = Senryu("ラッキーピエロ", "何食えばいい", "悩み多し")
     val names = listOf(
         Senryu(mockSenryu1.firstLine, mockSenryu1.secondLine, mockSenryu1.thirdLine),
         Senryu(mockSenryu2.firstLine, mockSenryu2.secondLine, mockSenryu2.thirdLine),

--- a/app/src/main/java/jp/chocofac/charlie/ui/page/ranking/HistoryRankingScreen.kt
+++ b/app/src/main/java/jp/chocofac/charlie/ui/page/ranking/HistoryRankingScreen.kt
@@ -1,0 +1,25 @@
+package jp.chocofac.charlie.ui.page.ranking
+
+import androidx.compose.runtime.Composable
+
+@Composable
+fun HistoryRankingScreen() {
+    HistoryRankingContent()
+}
+
+@Composable
+fun HistoryRankingContent() {
+    val mockSenryu1 = Senryu("枯れ葉舞う", "街路樹揺らし", "電線だけ立つ")
+    val mockSenryu2 = Senryu("険しい坂", "過去の火災が", "心探る")
+    val mockSenryu3 = Senryu("撃てば", "壊せるかな", "五稜郭")
+    val names = listOf(
+        Senryu(mockSenryu1.firstLine, mockSenryu1.secondLine, mockSenryu1.thirdLine),
+        Senryu(mockSenryu2.firstLine, mockSenryu2.secondLine, mockSenryu2.thirdLine),
+        Senryu(mockSenryu3.firstLine, mockSenryu3.secondLine, mockSenryu3.thirdLine),
+        // 投稿数かさ増 2set分繰り返し
+        Senryu(mockSenryu1.firstLine, mockSenryu1.secondLine, mockSenryu1.thirdLine),
+        Senryu(mockSenryu2.firstLine, mockSenryu2.secondLine, mockSenryu2.thirdLine),
+        Senryu(mockSenryu3.firstLine, mockSenryu3.secondLine, mockSenryu3.thirdLine),
+    )
+    SenryuCardList(names = names)
+}

--- a/app/src/main/java/jp/chocofac/charlie/ui/page/ranking/MtHakodateRankingScreen.kt
+++ b/app/src/main/java/jp/chocofac/charlie/ui/page/ranking/MtHakodateRankingScreen.kt
@@ -3,15 +3,15 @@ package jp.chocofac.charlie.ui.page.ranking
 import androidx.compose.runtime.Composable
 
 @Composable
-fun FunRankingScreen() {
-    FunRankingContent()
+fun MtHakodateRankingScreen() {
+    MtHakodateRankingContent()
 }
 
 @Composable
-fun FunRankingContent() {
-    val mockSenryu1 = Senryu("未来の夢", "広がる世界を", "手に取りたい")
-    val mockSenryu2 = Senryu("未来を見る", "ガラス張りの恐怖", "胸がざわめく")
-    val mockSenryu3 = Senryu("未来の夜", "美しく輝く", "感動の景色")
+fun MtHakodateRankingContent() {
+    val mockSenryu1 = Senryu("雲に隠れ", "函館山の夜", "見えず悔やむ")
+    val mockSenryu2 = Senryu("函館山", "夜景に酔いしれる", "心躍う")
+    val mockSenryu3 = Senryu("駆け上がる", "忙しきロープウェイ", "胸はしめつけ")
     val names = listOf(
         Senryu(mockSenryu1.firstLine, mockSenryu1.secondLine, mockSenryu1.thirdLine),
         Senryu(mockSenryu2.firstLine, mockSenryu2.secondLine, mockSenryu2.thirdLine),

--- a/app/src/main/java/jp/chocofac/charlie/ui/page/ranking/RankingScreen.kt
+++ b/app/src/main/java/jp/chocofac/charlie/ui/page/ranking/RankingScreen.kt
@@ -262,7 +262,7 @@ fun TabScreen() {
             2 -> MtHakodateRankingScreen()
             3 -> GourmetRankingScreen()
             4 -> HistoryRankingScreen()
-            5 -> RankingContent()
+            5 -> TrainRankingScreen()
         }
     }
 }

--- a/app/src/main/java/jp/chocofac/charlie/ui/page/ranking/RankingScreen.kt
+++ b/app/src/main/java/jp/chocofac/charlie/ui/page/ranking/RankingScreen.kt
@@ -1,30 +1,18 @@
-package jp.chocofac.charlie.ui.page
+package jp.chocofac.charlie.ui.page.ranking
 
-import android.graphics.Bitmap
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Home
-import androidx.compose.material.icons.filled.Info
-import androidx.compose.material.icons.filled.Lock
-import androidx.compose.material.icons.filled.Phone
-import androidx.compose.material.icons.filled.Settings
-import androidx.compose.material.icons.filled.Star
-import androidx.compose.material.icons.filled.Warning
-import androidx.compose.material.icons.outlined.Home
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
-import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ScrollableTabRow
 import androidx.compose.material3.Tab
@@ -34,13 +22,10 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
-import androidx.compose.ui.graphics.ImageBitmap
-import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
@@ -273,7 +258,7 @@ fun TabScreen() {
         }
         when (tabIndex) {
             0 -> RankingContent()
-            1 -> RankingContent()
+            1 -> FunRankingScreen()
             2 -> RankingContent()
             3 -> RankingContent()
             4 -> RankingContent()

--- a/app/src/main/java/jp/chocofac/charlie/ui/page/ranking/RankingScreen.kt
+++ b/app/src/main/java/jp/chocofac/charlie/ui/page/ranking/RankingScreen.kt
@@ -261,7 +261,7 @@ fun TabScreen() {
             1 -> FunRankingScreen()
             2 -> MtHakodateRankingScreen()
             3 -> GourmetRankingScreen()
-            4 -> RankingContent()
+            4 -> HistoryRankingScreen()
             5 -> RankingContent()
         }
     }

--- a/app/src/main/java/jp/chocofac/charlie/ui/page/ranking/RankingScreen.kt
+++ b/app/src/main/java/jp/chocofac/charlie/ui/page/ranking/RankingScreen.kt
@@ -259,8 +259,8 @@ fun TabScreen() {
         when (tabIndex) {
             0 -> RankingContent()
             1 -> FunRankingScreen()
-            2 -> RankingContent()
-            3 -> RankingContent()
+            2 -> MtHakodateRankingScreen()
+            3 -> GourmetRankingScreen()
             4 -> RankingContent()
             5 -> RankingContent()
         }

--- a/app/src/main/java/jp/chocofac/charlie/ui/page/ranking/TrainRankingScreen.kt
+++ b/app/src/main/java/jp/chocofac/charlie/ui/page/ranking/TrainRankingScreen.kt
@@ -1,0 +1,25 @@
+package jp.chocofac.charlie.ui.page.ranking
+
+import androidx.compose.runtime.Composable
+
+@Composable
+fun TrainRankingScreen() {
+    TrainRankingContent()
+}
+
+@Composable
+fun TrainRankingContent() {
+    val mockSenryu1 = Senryu("市電の音", "懐かしさが", "心を満たす")
+    val mockSenryu2 = Senryu("市電通る", "事故心配する", "私の気持ち")
+    val mockSenryu3 = Senryu("車窓に映える", "市電のラッピング", "心躍る")
+    val names = listOf(
+        Senryu(mockSenryu1.firstLine, mockSenryu1.secondLine, mockSenryu1.thirdLine),
+        Senryu(mockSenryu2.firstLine, mockSenryu2.secondLine, mockSenryu2.thirdLine),
+        Senryu(mockSenryu3.firstLine, mockSenryu3.secondLine, mockSenryu3.thirdLine),
+        // 投稿数かさ増 2set分繰り返し
+        Senryu(mockSenryu1.firstLine, mockSenryu1.secondLine, mockSenryu1.thirdLine),
+        Senryu(mockSenryu2.firstLine, mockSenryu2.secondLine, mockSenryu2.thirdLine),
+        Senryu(mockSenryu3.firstLine, mockSenryu3.secondLine, mockSenryu3.thirdLine),
+    )
+    SenryuCardList(names = names)
+}


### PR DESCRIPTION
- [FEAT] 川柳ランキング一覧でタグごとに適切なデモデータ(ハリボテ)を表示するように改修